### PR TITLE
feat: Allow individual bar colors and fix project metadata

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tryingtorun/kmpcharts/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/tryingtorun/kmpcharts/App.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -36,6 +37,7 @@ import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import kotlin.random.Random
 
 
 @Composable
@@ -75,10 +77,17 @@ fun App() {
                     val data = Sample.irelandMonthlyTemperatureData
                     val max = data.maxOf { it.yValue }
 
+                    val brushes = data.map { it ->
+                        val red = Random.nextFloat()
+                        val green = Random.nextFloat()
+                        val blue = Random.nextFloat()
+                        SolidColor(Color(red = red, green = green, blue = blue))
+                    }
 
                     BarChart(
                         data = data,
                         config = BarChartConfig(
+                            barFillBrushes = brushes,
                             chartConfig = ChartConfig(
                                 rangeRectangleConfig = RangeRectangleConfig(
                                     display = true,
@@ -108,7 +117,7 @@ fun App() {
                                 ),
                                 leftAxisConfig = AxisConfig(
                                     minValue = 0.0, // make sure we can see a bar for the smallest value by using an even smaller value for the axis (we could calculate this)
-                                    maxValue = if( max > 18.0 ) max else 20.0,
+                                    maxValue = if (max > 18.0) max else 20.0,
                                     valueFormatter = {
                                         "${it.toInt()}°C"
                                     },
@@ -186,9 +195,8 @@ fun App() {
 }
 
 
-
 fun Int.toMonthShortName(): String {
-    return when(this){
+    return when (this) {
         1 -> "Jan"
         2 -> "Feb"
         3 -> "Mar"
@@ -208,7 +216,7 @@ fun Int.toMonthShortName(): String {
 fun Int.toDateString(): String {
     val instant = Instant.fromEpochSeconds(this.toLong())
     val dt = instant.toLocalDateTime(TimeZone.currentSystemDefault())
-    return "${dt.date.dayOfMonth} ${(dt.date.month.ordinal+1).toMonthShortName()}"
+    return "${dt.date.dayOfMonth} ${(dt.date.month.ordinal + 1).toMonthShortName()}"
 }
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kmpcharts = "0.6.0-alpha"
+kmpcharts = "0.7.0-alpha"
 agp = "8.11.1"
 android-compileSdk = "36"
 android-minSdk = "24"

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -83,10 +83,10 @@ mavenPublishing {
     coordinates("com.tryingtorun", "kmpcharts", version as String?)
 
     pom {
-        name = "FMP Charts"
+        name = "KMP Charts"
         description = "A cross platform library for charts"
         inceptionYear = "2025"
-        url = "https://github.com/niallermoran/fmpcharts/"
+        url = "https://github.com/niallermoran/kmpcharts/"
         licenses {
             license {
                 name = "The Apache License, Version 2.0"
@@ -102,9 +102,9 @@ mavenPublishing {
             }
         }
         scm {
-            url = "https://github.com/niallermoran/fmpcharts/"
-            connection = "scm:git:git://github.com/niallermoran/fmpcharts.git"
-            developerConnection = "scm:git:ssh://git@github.com/niallermoran/fmpcharts.git"
+            url = "https://github.com/niallermoran/kmpcharts/"
+            connection = "scm:git:git://github.com/niallermoran/kmpcharts.git"
+            developerConnection = "scm:git:ssh://git@github.com/niallermoran/kmpcharts.git"
         }
     }
 }

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/BarChart.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/BarChart.kt
@@ -179,8 +179,14 @@ fun BarChart(
                         ) {
                             coordinates.forEachIndexed { index, coordinate ->
 
+                                val brush = if ( config.barFillBrushes.isNullOrEmpty() || index >= config.barFillBrushes.size ) {
+                                    config.barFillBrush
+                                } else {
+                                    config.barFillBrushes[index]
+                                }
+
                                 drawRoundRect(
-                                    brush = config.barFillBrush,
+                                    brush = brush,
                                     topLeft = Offset(
                                         coordinate.x - barDimensions.barWidthInPixels / 2,
                                         coordinate.y

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/ChartConfig.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/ChartConfig.kt
@@ -187,12 +187,16 @@ data class BarChartConfig(
     val barCornerRadius: Float = 10f,
 
     /**
-     * The color of each bar
+     * The default color of each bar
      */
     val barFillBrush: Brush = Brush.linearGradient(
         colors = listOf(Color(0xFF45B7D1), Color(0xFF96CEB4))
-    )
+    ),
 
+    /**
+     * The list of brushes to use to fill each bar individually. If this is provided, it will override [barFillBrush] for each bar based on its index
+     */
+    val barFillBrushes: List<Brush>? = null
 
 )
 


### PR DESCRIPTION
This commit introduces the ability to specify a unique color (Brush) for each bar in a BarChart.

- **BarChart:**
  - Added `barFillBrushes: List<Brush>?` to `BarChartConfig`.
  - If `barFillBrushes` is provided, each bar will be colored using the brush at the corresponding index.
  - If it's null, empty, or an index is out of bounds, the default `barFillBrush` is used as a fallback.
- **Sample App:**
  - Updated the BarChart example to demonstrate the new per-bar coloring feature using randomly generated colors.
- **Project Metadata:**
  - Corrected the project name from "FMP Charts" to "KMP Charts" in `build.gradle.kts`.
  - Updated repository URLs to reflect the new project name.
  - Incremented the library version.