### PR TITLE
feat: Added label formatter for BarChart

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tryingtorun/kmpcharts/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/tryingtorun/kmpcharts/App.kt
@@ -87,6 +87,13 @@ fun App() {
                     BarChart(
                         data = data,
                         config = BarChartConfig(
+                            labelFormatter = { i, x,y ->
+
+                                if( i % 2 == 0 )  // show label for every second bar only to avoid clutter
+                                    ""
+                                else
+                                    "${y.toInt()}°C"
+                            },
                             barFillBrushes = brushes,
                             chartConfig = ChartConfig(
                                 rangeRectangleConfig = RangeRectangleConfig(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kmpcharts = "0.7.0-alpha"
+kmpcharts = "0.8.0-alpha"
 agp = "8.11.1"
 android-compileSdk = "36"
 android-minSdk = "24"

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/BarChart.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/BarChart.kt
@@ -54,7 +54,7 @@ fun BarChart(
 
     Box(modifier = modifier) {
 
-        if(data.isNotEmpty()) {
+        if (data.isNotEmpty()) {
             BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
 
                 val height = maxHeight
@@ -179,11 +179,12 @@ fun BarChart(
                         ) {
                             coordinates.forEachIndexed { index, coordinate ->
 
-                                val brush = if ( config.barFillBrushes.isNullOrEmpty() || index >= config.barFillBrushes.size ) {
-                                    config.barFillBrush
-                                } else {
-                                    config.barFillBrushes[index]
-                                }
+                                val brush =
+                                    if (config.barFillBrushes.isNullOrEmpty() || index >= config.barFillBrushes.size) {
+                                        config.barFillBrush
+                                    } else {
+                                        config.barFillBrushes[index]
+                                    }
 
                                 drawRoundRect(
                                     brush = brush,
@@ -200,6 +201,27 @@ fun BarChart(
                                         config.barCornerRadius
                                     )
                                 )
+
+                                // place text label if formatter is provided
+                                if (config.labelFormatter != null) {
+
+                                    val label = config.labelFormatter.invoke(
+                                        index,
+                                        data[index].xValue,
+                                        data[index].yValue
+                                    )
+
+                                    drawText(
+                                        textMeasurer = textMeasurer,
+                                        text = label,
+                                        topLeft = Offset(
+                                            x = coordinate.x - textMeasurer.measure(label).size.width / 2,
+                                            y = coordinate.y - textMeasurer.measure(label).size.height - 5.dp.toPx(
+                                                density
+                                            )
+                                        )
+                                    )
+                                }
 
                             }
                             if (config.chartConfig.rangeRectangleConfig.display) {
@@ -284,10 +306,12 @@ fun BarChart(
                 }
 
             }
-        }
-        else{
-            Box(modifier= Modifier.fillMaxSize().border(width=1.dp, color= Color.LightGray), contentAlignment = androidx.compose.ui.Alignment.Center) {
-                Text(text="No Data", textAlign = TextAlign.Center)
+        } else {
+            Box(
+                modifier = Modifier.fillMaxSize().border(width = 1.dp, color = Color.LightGray),
+                contentAlignment = androidx.compose.ui.Alignment.Center
+            ) {
+                Text(text = "No Data", textAlign = TextAlign.Center)
             }
         }
     }

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/ChartConfig.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/ChartConfig.kt
@@ -196,7 +196,13 @@ data class BarChartConfig(
     /**
      * The list of brushes to use to fill each bar individually. If this is provided, it will override [barFillBrush] for each bar based on its index
      */
-    val barFillBrushes: List<Brush>? = null
+    val barFillBrushes: List<Brush>? = null,
+
+
+    /**
+     * The formatter to use to display values on top of the bars, leave nul for no labels
+     */
+    val labelFormatter: ((index:Int, x:Double, y:Double) -> String)? = null,
 
 )
 


### PR DESCRIPTION
This commit introduces a new `labelFormatter` property to `BarChartConfig`. This allows for the display of custom text labels above each bar.

- **`BarChartConfig`**: Added an optional `labelFormatter` lambda that takes the bar's index, x-value, and y-value to return a `String` label. If null, no labels are shown.
- **`BarChart`**: Implemented the logic to draw the text returned by `labelFormatter` above each corresponding bar.
- **Sample App (`App.kt`)**: Updated the BarChart example to demonstrate the new `labelFormatter`, showing a label for every second bar to prevent clutter.