### PR TITLE
feat: Add popup value formatter and improve popup layout

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kmpcharts = "0.11.1-alpha"
+kmpcharts = "0.12.1-alpha"
 agp = "8.13.0"
 android-compileSdk = "36"
 android-minSdk = "24"


### PR DESCRIPTION
This commit introduces several enhancements to the chart popups:

- **Added `valueFormatter` to `PopupConfig`**: This allows for custom formatting of the popup's primary value. The sample app is updated to use this to append "°C" to the temperature.
- **Improved Popup Layout**:
    - Reduced the default `width` of the popup from 200.dp to 100.dp for a more compact appearance.
    - Set `minLines = 1` for the popup's text elements to prevent them from collapsing and causing layout shifts.
- **Bug Fix**: Corrected a check in `BarChart.kt` to prevent a crash when `crossHairConfig` was not null but its `lineStyle.display` was false.