### PR TITLE
feat: Allow null chart configs for default rendering

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tryingtorun/kmpcharts/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/tryingtorun/kmpcharts/App.kt
@@ -1,8 +1,10 @@
 package com.tryingtorun.kmpcharts
 
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -10,10 +12,16 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -46,6 +54,9 @@ import kotlin.time.Instant
 @Preview
 fun App() {
 
+    var showMinimumConfig by remember { mutableStateOf(false) }
+
+
     AppTheme {
 
         Scaffold { padding ->
@@ -63,6 +74,21 @@ fun App() {
 
                 Spacer(modifier = Modifier.height(22.dp))
 
+                Row (verticalAlignment = Alignment.CenterVertically, modifier = Modifier.clickable(onClick = {
+                    showMinimumConfig = !showMinimumConfig
+                })){
+                    Checkbox(
+                        checked = showMinimumConfig,
+                        onCheckedChange = {
+                            showMinimumConfig = !showMinimumConfig
+                        },
+                        enabled = true,
+                    )
+                    Text(text="Show Minimum Configuration")
+                }
+
+                Spacer(modifier = Modifier.height(22.dp))
+
                 Text(
                     text = "Monthly Average Irish Temperatures (Celsius)",
                     textAlign = TextAlign.Center,
@@ -72,108 +98,18 @@ fun App() {
 
 
                 Box(modifier = Modifier.fillMaxWidth().height(300.dp).padding(12.dp)) {
-
-
-
                     val data = Sample.irelandMonthlyTemperatureData
-                    val averageTemp = Sample.irelandMonthlyTemperatureData.sumOf { it.yValue } / data.size
-                    val max = data.maxOf { it.yValue }
-                    val min = data.minOf { it.yValue }
-
-
-
-                    val brushes = data.map { it ->
-                        val red = Random.nextFloat()
-                        val green = Random.nextFloat()
-                        val blue = Random.nextFloat()
-                        SolidColor(Color(red = red, green = green, blue = blue))
-                    }
-
-
                     BarChart(
                         data = data,
-                        config = BarChartConfig(
-                            labelFormatter = { i, data ->
-
-                                if( i % 2 == 0 )  // show label for every second bar only to avoid clutter
-                                    ""
-                                else
-                                    "${data.yValue.toInt()}°C"
-                            },
-                            barFillBrushes = brushes,
-                            chartConfig = ChartConfig(
-                                popupConfig = PopupConfig(
-                                    valueFormatter = {
-                                        "${it.toInt()}°C"
-                                    },
-                                    valueTextColor = MaterialTheme.colorScheme.onSurface,
-                                    summaryTextColor = MaterialTheme.colorScheme.onSurface,
-                                ),
-                                defaultAxisTextAndLineColor = MaterialTheme.colorScheme.onSurface,
-                                horizontalGuideLines = listOf(
-                                    HorizontalGuideLineConfig(
-                                        label = "Avg: ${averageTemp.toInt()} ℃",
-                                        labelStyle = TextStyle(
-                                            color = MaterialTheme.colorScheme.onSurface,
-                                            fontSize = 10.sp
-                                        ),
-                                        labelPosition = HorizontalGuideLineConfig.LabelPosition.LEFT_ABOVE,
-                                        yValue = averageTemp.toFloat()
-                                    ),
-                                    HorizontalGuideLineConfig(
-                                        label = "Min: ${min.toInt()} ℃",
-                                        labelPosition = HorizontalGuideLineConfig.LabelPosition.LEFT_ABOVE,
-                                        labelStyle = TextStyle(
-                                            color = MaterialTheme.colorScheme.onSurface,
-                                            fontSize = 10.sp
-                                        ),
-                                        color = Color.Blue,
-                                        yValue = min.toFloat()
-                                    ),
-                                    HorizontalGuideLineConfig(
-                                        label = "Max: ${max.toInt()} ℃",
-                                        labelPosition = HorizontalGuideLineConfig.LabelPosition.LEFT_ABOVE,
-                                        labelStyle = TextStyle(
-                                            color = MaterialTheme.colorScheme.onSurface,
-                                            fontSize = 10.sp
-                                        ),
-                                        color = Color.Red   ,
-                                        yValue = max.toFloat()
-                                    )
-                                ),
-                                rangeRectangleConfig = RangeRectangleConfig(
-                                    minY = 10f,
-                                    maxY = 18f,
-                                    label = "Grass Growth Range",
-                                ),
-                                leftGutterWidth = 15.dp, // use a small gutter so that the first and last bar are clearly visible. Change this based on your data set
-                                rightGutterWidth = 15.dp,
-                                bottomAxisConfig = AxisConfig(
-                                    valueFormatter = {
-                                        when (it.toInt()) {
-                                            in 1..12 -> it.toInt().toMonthShortName()
-                                                .take(3)
-
-                                            else -> throw IllegalArgumentException("Month number must be between 1 and 12")
-                                        }
-                                    },
-                                    numberOfLabelsToShow = 4, // don't want clutter on the bottom axis then change this, depending on your data set
-                                    shiftLastLabel = false, // shift the last label to the left to avoid clipping if not using rightgutterwidth above
-                                    color = MaterialTheme.colorScheme.onSurface
-                                ),
-                                leftAxisConfig = AxisConfig(
-                                    minValue = 0.0, // make sure we can see a bar for the smallest value by using an even smaller value for the axis (we could calculate this)
-                                    maxValue = if (max > 18.0) max else 20.0,
-                                    valueFormatter = {
-                                        "${it.toInt()}°C"
-                                    },
-                                    numberOfLabelsToShow = 5,
-                                    color = MaterialTheme.colorScheme.onSurface
-                                )
-                            )
-                        )
+                        config = if( showMinimumConfig ) null else Config.getBarchartSampleConfig(data)
                     )
                 }
+
+                Spacer(modifier = Modifier.height(22.dp))
+
+                HorizontalDivider()
+
+                Spacer(modifier = Modifier.height(22.dp))
 
                 Text(
                     text = "2024 Bitcoin Price Trend",
@@ -182,79 +118,10 @@ fun App() {
                 )
 
                 Box(modifier = Modifier.fillMaxWidth().height(300.dp).padding(12.dp)) {
-
-
                     val data = Sample.bitcoinWeekly2024
-
-                    val avg = data.sumOf { it.yValue } / data.size
-                    val min = data.minOf { it.yValue }
-                    val max = data.maxOf { it.yValue }
-
-
                     LineChart(
                         data = data,
-                        lineChartConfig = LineChartConfig(
-                            chartConfig = ChartConfig(
-                                defaultAxisTextAndLineColor = MaterialTheme.colorScheme.onSurface,
-                                horizontalGuideLines = listOf(
-                                    HorizontalGuideLineConfig(
-                                        label = "Avg: $${avg.toInt()}",
-                                        labelPosition = HorizontalGuideLineConfig.LabelPosition.LEFT_ABOVE,
-                                        yValue = avg.toFloat(),
-                                        labelStyle = TextStyle(
-                                            color = MaterialTheme.colorScheme.onSurface,
-                                            fontSize = 10.sp
-                                        ),
-                                    ),
-                                    HorizontalGuideLineConfig(
-                                        label = "Min: $${min.toInt()}",
-                                        labelPosition = HorizontalGuideLineConfig.LabelPosition.LEFT_ABOVE,
-                                        color = Color.Blue,
-                                        yValue = min.toFloat(),
-                                        labelStyle = TextStyle(
-                                            color = MaterialTheme.colorScheme.onSurface,
-                                            fontSize = 10.sp
-                                        ),
-                                    ),
-                                    HorizontalGuideLineConfig(
-                                        label = "Max: $${max.toInt()}",
-                                        labelPosition = HorizontalGuideLineConfig.LabelPosition.LEFT_UNDER,
-                                        color = Color.Red   ,
-                                        yValue = max.toFloat(),
-                                        labelStyle = TextStyle(
-                                            color = MaterialTheme.colorScheme.onSurface,
-                                            fontSize = 10.sp
-                                        ),
-                                    )
-                                ),
-                                bottomAxisMethod = BottomAxisTicksAndLabelsDrawMethod.DIVIDE_EQUALLY,
-                                bottomAxisConfig = AxisConfig(
-                                    display = true,
-                                    valueFormatter = {
-                                        it.toInt().toDateString()
-                                    },
-                                    numberOfLabelsToShow = 5, // don't want clutter on the bottom axis then change this, depending on your data set
-                                    shiftLastLabel = true, // shift the last label to the left to avoid clipping if not using rightgutterwidth above
-                                    shiftFirstLabel = true,
-                                    color = MaterialTheme.colorScheme.onSurface
-                                ),
-                                leftAxisConfig = AxisConfig(
-                                    display = false,
-                                    valueFormatter = {
-                                        it.toCurrencyString()
-                                    },
-                                    numberOfLabelsToShow = 10,
-                                    color = MaterialTheme.colorScheme.onSurface
-                                ),
-                                popupConfig = PopupConfig(
-                                    valueFormatter = {
-                                        it.toCurrencyString()
-                                    },
-                                    valueTextColor = MaterialTheme.colorScheme.onSurface,
-                                    summaryTextColor = MaterialTheme.colorScheme.onSurface,
-                                )
-                            )
-                        )
+                        lineChartConfig = if( showMinimumConfig) null else Config.getLineChartSampleConfig(data)
                     )
                 }
 

--- a/composeApp/src/commonMain/kotlin/com/tryingtorun/kmpcharts/Config.kt
+++ b/composeApp/src/commonMain/kotlin/com/tryingtorun/kmpcharts/Config.kt
@@ -1,0 +1,220 @@
+package com.tryingtorun.kmpcharts
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.tryingtorun.kmpcharts.library.AxisConfig
+import com.tryingtorun.kmpcharts.library.BarChartConfig
+import com.tryingtorun.kmpcharts.library.BottomAxisTicksAndLabelsDrawMethod
+import com.tryingtorun.kmpcharts.library.ChartConfig
+import com.tryingtorun.kmpcharts.library.ChartDataPoint
+import com.tryingtorun.kmpcharts.library.HorizontalGuideLineConfig
+import com.tryingtorun.kmpcharts.library.LineChartConfig
+import com.tryingtorun.kmpcharts.library.PopupConfig
+import com.tryingtorun.kmpcharts.library.RangeRectangleConfig
+import com.tryingtorun.kmpcharts.library.Sample
+import kotlin.random.Random
+
+class Config {
+
+    companion object {
+
+        @Composable
+        fun getLineChartSampleConfig(data: List<ChartDataPoint>): LineChartConfig {
+
+            val avg = data.sumOf { it.yValue } / data.size
+            val min = data.minOf { it.yValue }
+            val max = data.maxOf { it.yValue }
+
+            return LineChartConfig(
+                chartConfig = ChartConfig(
+                    defaultAxisTextAndLineColor = MaterialTheme.colorScheme.onSurface,
+                    horizontalGuideLines = listOf(
+                        HorizontalGuideLineConfig(
+                            label = "Avg: $${avg.toInt()}",
+                            labelPosition = HorizontalGuideLineConfig.LabelPosition.LEFT_ABOVE,
+                            yValue = avg.toFloat(),
+                            labelStyle = TextStyle(
+                                color = MaterialTheme.colorScheme.onSurface,
+                                fontSize = 10.sp
+                            ),
+                        ),
+                        HorizontalGuideLineConfig(
+                            label = "Min: $${min.toInt()}",
+                            labelPosition = HorizontalGuideLineConfig.LabelPosition.LEFT_ABOVE,
+                            color = Color.Blue,
+                            yValue = min.toFloat(),
+                            labelStyle = TextStyle(
+                                color = MaterialTheme.colorScheme.onSurface,
+                                fontSize = 10.sp
+                            ),
+                        ),
+                        HorizontalGuideLineConfig(
+                            label = "Max: $${max.toInt()}",
+                            labelPosition = HorizontalGuideLineConfig.LabelPosition.LEFT_UNDER,
+                            color = Color.Red,
+                            yValue = max.toFloat(),
+                            labelStyle = TextStyle(
+                                color = MaterialTheme.colorScheme.onSurface,
+                                fontSize = 10.sp
+                            ),
+                        )
+                    ),
+                    bottomAxisMethod = BottomAxisTicksAndLabelsDrawMethod.DIVIDE_EQUALLY,
+                    bottomAxisConfig = AxisConfig(
+                        valueFormatter = {
+                            it.toInt().toDateString()
+                        },
+                        numberOfLabelsToShow = 5, // don't want clutter on the bottom axis then change this, depending on your data set
+                        shiftLastLabel = true, // shift the last label to the left to avoid clipping if not using rightgutterwidth above
+                        shiftFirstLabel = true,
+                        color = MaterialTheme.colorScheme.onSurface
+                    ),
+                    leftAxisConfig = AxisConfig(
+                        valueFormatter = {
+                            it.toCurrencyString()
+                        },
+                        numberOfLabelsToShow = 10,
+                        color = MaterialTheme.colorScheme.onSurface
+                    ),
+                    popupConfig = PopupConfig(
+                        valueFormatter = {
+                            it.toCurrencyString()
+                        },
+                        valueTextColor = MaterialTheme.colorScheme.onSurface,
+                        summaryTextColor = MaterialTheme.colorScheme.onSurface,
+                    )
+                )
+            )
+        }
+
+
+        @Composable
+        fun getLineChartMinimalConfig(data: List<ChartDataPoint>): LineChartConfig {
+
+            return LineChartConfig(
+                chartConfig = ChartConfig(
+                    defaultAxisTextAndLineColor = MaterialTheme.colorScheme.onSurface,
+                )
+            )
+        }
+
+        @Composable
+        fun getBarchartMinimalConfig(data: List<ChartDataPoint>): BarChartConfig {
+
+            val brushes = data.map { it ->
+                val red = Random.nextFloat()
+                val green = Random.nextFloat()
+                val blue = Random.nextFloat()
+                SolidColor(Color(red = red, green = green, blue = blue))
+            }
+
+            return BarChartConfig(
+           //     barFillBrushes = brushes,
+                chartConfig = ChartConfig(
+                    defaultAxisTextAndLineColor = MaterialTheme.colorScheme.onSurface,
+                )
+            )
+        }
+
+        @Composable
+        fun getBarchartSampleConfig(data: List<ChartDataPoint>): BarChartConfig {
+
+            val averageTemp = Sample.irelandMonthlyTemperatureData.sumOf { it.yValue } / data.size
+            val max = data.maxOf { it.yValue }
+            val min = data.minOf { it.yValue }
+
+            val brushes = data.map { it ->
+                val red = Random.nextFloat()
+                val green = Random.nextFloat()
+                val blue = Random.nextFloat()
+                SolidColor(Color(red = red, green = green, blue = blue))
+            }
+
+            return BarChartConfig(
+                labelFormatter = { i, data ->
+
+                    if (i % 2 == 0)  // show label for every second bar only to avoid clutter
+                        ""
+                    else
+                        "${data.yValue.toInt()}°C"
+                },
+                barFillBrushes = brushes,
+                chartConfig = ChartConfig(
+                    popupConfig = PopupConfig(
+                        valueFormatter = {
+                            "${it.toInt()}°C"
+                        },
+                        valueTextColor = MaterialTheme.colorScheme.onSurface,
+                        summaryTextColor = MaterialTheme.colorScheme.onSurface,
+                    ),
+                    defaultAxisTextAndLineColor = MaterialTheme.colorScheme.onSurface,
+                    horizontalGuideLines = listOf(
+                        HorizontalGuideLineConfig(
+                            label = "Avg: ${averageTemp.toInt()} ℃",
+                            labelStyle = TextStyle(
+                                color = MaterialTheme.colorScheme.onSurface,
+                                fontSize = 10.sp
+                            ),
+                            labelPosition = HorizontalGuideLineConfig.LabelPosition.LEFT_ABOVE,
+                            yValue = averageTemp.toFloat()
+                        ),
+                        HorizontalGuideLineConfig(
+                            label = "Min: ${min.toInt()} ℃",
+                            labelPosition = HorizontalGuideLineConfig.LabelPosition.LEFT_ABOVE,
+                            labelStyle = TextStyle(
+                                color = MaterialTheme.colorScheme.onSurface,
+                                fontSize = 10.sp
+                            ),
+                            color = Color.Blue,
+                            yValue = min.toFloat()
+                        ),
+                        HorizontalGuideLineConfig(
+                            label = "Max: ${max.toInt()} ℃",
+                            labelPosition = HorizontalGuideLineConfig.LabelPosition.LEFT_ABOVE,
+                            labelStyle = TextStyle(
+                                color = MaterialTheme.colorScheme.onSurface,
+                                fontSize = 10.sp
+                            ),
+                            color = Color.Red,
+                            yValue = max.toFloat()
+                        )
+                    ),
+                    rangeRectangleConfig = RangeRectangleConfig(
+                        minY = 10f,
+                        maxY = 18f,
+                        label = "Grass Growth Range",
+                    ),
+                    leftGutterWidth = 15.dp, // use a small gutter so that the first and last bar are clearly visible. Change this based on your data set
+                    rightGutterWidth = 15.dp,
+                    bottomAxisConfig = AxisConfig(
+                        valueFormatter = {
+                            when (it.toInt()) {
+                                in 1..12 -> it.toInt().toMonthShortName()
+                                    .take(3)
+
+                                else -> throw IllegalArgumentException("Month number must be between 1 and 12")
+                            }
+                        },
+                        numberOfLabelsToShow = 4, // don't want clutter on the bottom axis then change this, depending on your data set
+                        shiftLastLabel = false, // shift the last label to the left to avoid clipping if not using rightgutterwidth above
+                        color = MaterialTheme.colorScheme.onSurface
+                    ),
+                    leftAxisConfig = AxisConfig(
+                        minValue = 0.0, // make sure we can see a bar for the smallest value by using an even smaller value for the axis (we could calculate this)
+                        maxValue = if (max > 18.0) max else 20.0,
+                        valueFormatter = {
+                            "${it.toInt()}°C"
+                        },
+                        numberOfLabelsToShow = 5,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                )
+            )
+        }
+    }
+}

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/ChartConfig.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/ChartConfig.kt
@@ -19,15 +19,14 @@ import androidx.compose.ui.unit.sp
 data class ChartConfig(
 
     /**
-     * The default color to use for all line and text configs. Can be overriden by defined axis styles
+     * The default color to use for all line and text configs. Can be overridden by defined axis styles
      */
     val defaultAxisTextAndLineColor: Color,
 
-
     /**
-     * The configuration for the bottom axis
+     * The configuration for the bottom axis. If null not bottom axis, ticks or labels will be shown
      */
-    val bottomAxisConfig: AxisConfig,
+    val bottomAxisConfig: AxisConfig? = null,
 
     /**
      * The left gutter provides a gap between the start of the chart and the left axis
@@ -42,12 +41,7 @@ data class ChartConfig(
     /**
      * The configuration for the cross hair
      */
-    val crossHairConfig: CrossHairConfig = CrossHairConfig(
-        lineStyle = LineStyle(
-            display = true,
-            color = defaultAxisTextAndLineColor
-        )
-    ),
+    val crossHairConfig: CrossHairConfig? = null,
 
 
     /**
@@ -63,7 +57,7 @@ data class ChartConfig(
     /**
      * The configuration for the left axis
      */
-    val leftAxisConfig: AxisConfig = AxisConfig(color = defaultAxisTextAndLineColor),
+    val leftAxisConfig: AxisConfig? = null,
 
 
     /**

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/Model.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/Model.kt
@@ -40,12 +40,6 @@ data class AxisConfig(
     val color: Color,
 
     /**
-     * Whether or not to display the axis, ticks and labels. If false, nothing will be drawn for the axis. Must be true to show ticks and labels
-     */
-    val display: Boolean = true,
-
-
-    /**
      * The formatter to use to display values on the axis
      */
     val valueFormatter: (Double) -> String = { it.toPrecisionString(2) },
@@ -68,6 +62,7 @@ data class AxisConfig(
      * Whether or not to show ticks for each point on the axis
      */
     val showTicks: Boolean = true,
+
 
     /**
      * Whether or not to show labels for each point on the axis


### PR DESCRIPTION
This change makes the `config` properties for `BarChart` and `LineChart` nullable. If a null config is provided, the charts will now render with a minimal, default appearance. This simplifies the initial setup for developers who do not need extensive customization.

- **`BarChart` & `LineChart`:**
    - Updated to accept a nullable `config` (`BarChartConfig?` and `LineChartConfig?`).
    - The composables now provide default values and behaviors when the config is null, ensuring the chart still renders.
    - Dragging to show a popup is now disabled if the popup configuration is not provided.
    - Axis, ticks, and labels are only drawn if their respective configs exist.
- **`ChartConfig` & `AxisConfig`:**
    - `bottomAxisConfig`, `leftAxisConfig`, and `crossHairConfig` in `ChartConfig` are now nullable.
    - Removed the `display` property from `AxisConfig`, as its nullability now controls visibility.
- **Sample App (`App.kt`):**
    - Refactored chart configurations into a new `Config.kt` helper class.
    - Added a "Show Minimum Configuration" checkbox to toggle between the fully-featured chart and the new default (null config) rendering.