### PR TITLE
breaking change: remove defaultAxisTextAndLineColor and hardcoded colors

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tryingtorun/kmpcharts/Config.kt
+++ b/composeApp/src/commonMain/kotlin/com/tryingtorun/kmpcharts/Config.kt
@@ -14,9 +14,11 @@ import com.tryingtorun.kmpcharts.library.ChartConfig
 import com.tryingtorun.kmpcharts.library.ChartDataPoint
 import com.tryingtorun.kmpcharts.library.HorizontalGuideLineConfig
 import com.tryingtorun.kmpcharts.library.LineChartConfig
+import com.tryingtorun.kmpcharts.library.LineStyle
 import com.tryingtorun.kmpcharts.library.PopupConfig
 import com.tryingtorun.kmpcharts.library.RangeRectangleConfig
 import com.tryingtorun.kmpcharts.library.Sample
+import com.tryingtorun.kmpcharts.library.Scale
 import kotlin.random.Random
 
 class Config {
@@ -32,7 +34,6 @@ class Config {
 
             return LineChartConfig(
                 chartConfig = ChartConfig(
-                    defaultAxisTextAndLineColor = MaterialTheme.colorScheme.onSurface,
                     horizontalGuideLines = listOf(
                         HorizontalGuideLineConfig(
                             label = "Avg: $${avg.toInt()}",
@@ -72,14 +73,12 @@ class Config {
                         numberOfLabelsToShow = 5, // don't want clutter on the bottom axis then change this, depending on your data set
                         shiftLastLabel = true, // shift the last label to the left to avoid clipping if not using rightgutterwidth above
                         shiftFirstLabel = true,
-                        color = MaterialTheme.colorScheme.onSurface
                     ),
                     leftAxisConfig = AxisConfig(
                         valueFormatter = {
                             it.toCurrencyString()
                         },
                         numberOfLabelsToShow = 10,
-                        color = MaterialTheme.colorScheme.onSurface
                     ),
                     popupConfig = PopupConfig(
                         valueFormatter = {
@@ -97,9 +96,7 @@ class Config {
         fun getLineChartMinimalConfig(data: List<ChartDataPoint>): LineChartConfig {
 
             return LineChartConfig(
-                chartConfig = ChartConfig(
-                    defaultAxisTextAndLineColor = MaterialTheme.colorScheme.onSurface,
-                )
+                chartConfig = ChartConfig()
             )
         }
 
@@ -115,9 +112,7 @@ class Config {
 
             return BarChartConfig(
            //     barFillBrushes = brushes,
-                chartConfig = ChartConfig(
-                    defaultAxisTextAndLineColor = MaterialTheme.colorScheme.onSurface,
-                )
+                chartConfig = ChartConfig()
             )
         }
 
@@ -152,7 +147,6 @@ class Config {
                         valueTextColor = MaterialTheme.colorScheme.onSurface,
                         summaryTextColor = MaterialTheme.colorScheme.onSurface,
                     ),
-                    defaultAxisTextAndLineColor = MaterialTheme.colorScheme.onSurface,
                     horizontalGuideLines = listOf(
                         HorizontalGuideLineConfig(
                             label = "Avg: ${averageTemp.toInt()} ℃",
@@ -202,16 +196,15 @@ class Config {
                         },
                         numberOfLabelsToShow = 4, // don't want clutter on the bottom axis then change this, depending on your data set
                         shiftLastLabel = false, // shift the last label to the left to avoid clipping if not using rightgutterwidth above
-                        color = MaterialTheme.colorScheme.onSurface
                     ),
                     leftAxisConfig = AxisConfig(
-                        minValue = 0.0, // make sure we can see a bar for the smallest value by using an even smaller value for the axis (we could calculate this)
-                        maxValue = if (max > 18.0) max else 20.0,
+                        scale = Scale(min=0.0, max=if (max > 18.0) max else 20.0),
                         valueFormatter = {
                             "${it.toInt()}°C"
                         },
                         numberOfLabelsToShow = 5,
-                        color = MaterialTheme.colorScheme.onSurface
+                        showLabels = true,
+                        showTicks = true,
                     )
                 )
             )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kmpcharts = "0.12.1-alpha"
+kmpcharts = "0.13.0-alpha"
 agp = "8.13.0"
 android-compileSdk = "36"
 android-minSdk = "24"

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/BarChart.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/BarChart.kt
@@ -371,7 +371,7 @@ fun BarChart(
                                 )
                             }
 
-                            if (config?.chartConfig?.crossHairConfig != null && config.chartConfig.crossHairConfig.lineStyle.display) {
+                            if (config?.chartConfig?.crossHairConfig != null) {
                                 CrossHairs(
                                     config = config.chartConfig,
                                     coordinate = selectedCoordinate

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/ChartConfig.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/ChartConfig.kt
@@ -19,11 +19,6 @@ import androidx.compose.ui.unit.sp
 data class ChartConfig(
 
     /**
-     * The default color to use for all line and text configs. Can be overridden by defined axis styles
-     */
-    val defaultAxisTextAndLineColor: Color,
-
-    /**
      * The configuration for the bottom axis. If null not bottom axis, ticks or labels will be shown
      */
     val bottomAxisConfig: AxisConfig? = null,
@@ -65,13 +60,17 @@ data class ChartConfig(
      */
     val popupConfig: PopupConfig?= null,
 
-
-
     /**
      * The configuration for the range rectangle
      */
     val rangeRectangleConfig: RangeRectangleConfig? = null
 )
+
+/**
+ * Defines the scale range for an axis
+ */
+data class Scale( val min: Double, val max: Double)
+
 
 /**
  * Method to use to display labels and ticks on the bottom axis. If MATCH_POINT the ticks and labels will be drawn for each data point.
@@ -182,8 +181,7 @@ data class LineChartConfig(
      * The style to use for the chart line
      */
     val lineStyle: LineStyle = LineStyle(
-        display = true,
-        color = Color(0xFF45B7D1),
+        color = defaultLineColor,
         stroke = Stroke(
             width = 2f,
             cap = StrokeCap.Round,

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/ChartHelper.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/ChartHelper.kt
@@ -114,8 +114,8 @@ object ChartHelper {
         value: Float
     ): Float {
 
-        val minY = config.leftAxisConfig?.minValue ?: data.minOf { it.yValue }
-        val maxY = config.leftAxisConfig?.maxValue ?: data.maxOf { it.yValue }
+        val minY = config.leftAxisConfig?.scale?.min ?: data.minOf { it.yValue }
+        val maxY = config.leftAxisConfig?.scale?.max ?: data.maxOf { it.yValue }
         val yRange = maxY - minY
 
         val plotAreaHeight = chartDimensions.plotAreaHeightPixels
@@ -135,9 +135,9 @@ object ChartHelper {
     ): List<DataPointPlotCoordinates> {
 
         val minX = data.minOf { it.xValue }
-        val minY = config?.leftAxisConfig?.minValue ?: data.minOf { it.yValue }
+        val minY = config?.leftAxisConfig?.scale?.min ?: data.minOf { it.yValue }
         val maxX = data.maxOf { it.xValue }
-        val maxY = config?.leftAxisConfig?.maxValue ?: data.maxOf { it.yValue }
+        val maxY = config?.leftAxisConfig?.scale?.max ?: data.maxOf { it.yValue }
 
         val xRange = maxX - minX
         val yRange = maxY - minY
@@ -184,8 +184,10 @@ object ChartHelper {
          * usableWidth = n * barWidth + (n-1) * spacing
          */
         val barWidth =
-            if (data.size == 1) availableWidth else availableWidth / (data.size + (config?.barWidthFactor ?: 0.8f ) * (data.size - 1))
-        val spacingBetweenBars = if (data.size == 1) 0f else barWidth * (config?.barWidthFactor ?:0.8f)
+            if (data.size == 1) availableWidth else availableWidth / (data.size + (config?.barWidthFactor
+                ?: 0.8f) * (data.size - 1))
+        val spacingBetweenBars =
+            if (data.size == 1) 0f else barWidth * (config?.barWidthFactor ?: 0.8f)
 
         return BarDimensions(
             barWidth = with(density) { barWidth.toDp() },
@@ -221,7 +223,7 @@ object ChartHelper {
             )
 
         val leftLabelMaxWidth = if (config == null) 0.dp else
-            if (config.leftAxisConfig?.lineStyle != null && config.leftAxisConfig.lineStyle.display) with(
+            if (config.leftAxisConfig?.lineStyle != null) with(
                 density
             ) { leftLabelSize.width.toDp() } else 0.dp
 
@@ -416,8 +418,8 @@ internal fun DrawScope.drawLeftAxisLabelsAndTicks(
         val width = size.width
         val height = size.height - chartDimensions.bottomAreaHeightPixels
 
-        val minY = config.leftAxisConfig.minValue ?: data.minOf { it.yValue }
-        val maxY = config.leftAxisConfig.maxValue ?: data.maxOf { it.yValue }
+        val minY = config.leftAxisConfig.scale?.min ?: data.minOf { it.yValue }
+        val maxY = config.leftAxisConfig.scale?.max ?: data.maxOf { it.yValue }
 
         val yRange = maxY - minY
 
@@ -429,15 +431,12 @@ internal fun DrawScope.drawLeftAxisLabelsAndTicks(
         /**
          * Draw axis line
          */
-        if (config.leftAxisConfig.lineStyle != null && config.leftAxisConfig.lineStyle.display) {
-            drawLine(
-                color = config.leftAxisConfig.lineStyle.color,
-                start = Offset(size.width, 0f),
-                end = Offset(size.width, height),
-                strokeWidth = config.leftAxisConfig.lineStyle.stroke.width
-            )
-        }
-
+        drawLine(
+            color = config.leftAxisConfig.lineStyle.color,
+            start = Offset(size.width, 0f),
+            end = Offset(size.width, height),
+            strokeWidth = config.leftAxisConfig.lineStyle.stroke.width
+        )
 
 
         for (i in 1..config.leftAxisConfig.numberOfLabelsToShow) {
@@ -521,14 +520,12 @@ internal fun DrawScope.drawBottomAxisLabelsAndTicks(
         /**
          * Draw the axis line
          */
-        if (config.bottomAxisConfig.lineStyle.display) {
             drawLine(
                 color = config.bottomAxisConfig.lineStyle.color,
                 strokeWidth = config.bottomAxisConfig.lineStyle.stroke.width,
                 start = Offset(x = startX, 0f),
                 end = Offset(size.width, 0f),
             )
-        }
 
         if (config.bottomAxisMethod == BottomAxisTicksAndLabelsDrawMethod.MATCH_POINT) {
 

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/Model.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/Model.kt
@@ -14,6 +14,8 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
+val defaultLineColor = Color.Gray // default color used that works for both themes
+
 /**
  * Data class representing a single bar in the chart
  */
@@ -35,11 +37,6 @@ data class DataPointPlotCoordinates(
 data class AxisConfig(
 
     /**
-     * Default color used for lines and text
-     */
-    val color: Color,
-
-    /**
      * The formatter to use to display values on the axis
      */
     val valueFormatter: (Double) -> String = { it.toPrecisionString(2) },
@@ -47,27 +44,27 @@ data class AxisConfig(
     /**
      * The style for the axis
      */
-    val lineStyle: LineStyle = LineStyle(
-        color = color,
-    ),
+    val lineStyle: LineStyle = LineStyle(),
 
     /**
      * The style for the grid lines
      */
-    val gridLineStyle: LineStyle = LineStyle(
-        color = color,
-    ),
+    val gridLineStyle: LineStyle = LineStyle(),
 
     /**
      * Whether or not to show ticks for each point on the axis
      */
     val showTicks: Boolean = true,
 
-
     /**
      * Whether or not to show labels for each point on the axis
      */
     val showLabels: Boolean = true,
+
+    /**
+     * Whether or not to show labels for each point on the axis
+     */
+    val showAxisLine: Boolean = true,
 
     /**
      * The length of the ticks
@@ -78,7 +75,7 @@ data class AxisConfig(
      * The style of the labels
      */
     val labelStyle: TextStyle = TextStyle(
-        color = color
+        color = defaultLineColor
     ),
 
     /**
@@ -87,16 +84,9 @@ data class AxisConfig(
     val labelPadding: PaddingValues = PaddingValues(6.dp),
 
     /**
-     * The minimum value is the smallest value to be represented on the axis.
-     * If left null will be automatically calculated from data.
+     * Defines the scale for the axis, if left null will be calculated from the data
      */
-    val minValue: Double? = null,
-
-    /**
-     * The maximum value is the largest value to be represented on the axis
-     * If left null will be automatically calculated from data.
-     */
-    val maxValue: Double? = null,
+    val scale: Scale? = null,
 
     /**
      * The number of labels to show on the axis.
@@ -119,8 +109,7 @@ data class AxisConfig(
 )
 
 data class LineStyle(
-    val display: Boolean = true,
-    val color: Color,
+    val color: Color = defaultLineColor,
     val stroke: Stroke = Stroke(
         width = 2f,
         cap = StrokeCap.Round,


### PR DESCRIPTION
This commit removes the `defaultAxisTextAndLineColor` from `ChartConfig` and replaces hardcoded colors with a new default color that is suitable for both light and dark themes.

### Key Changes:
- **Breaking Change**:
  - Removed `defaultAxisTextAndLineColor` from `ChartConfig`. Users will no longer set this global color.
  - The `color` property has been removed from `AxisConfig`. Axis and line colors are now managed through their respective `LineStyle`.
  - Introduced `Scale(min: Double, max: Double)` to replace the `minValue` and `maxValue` properties in `AxisConfig`.

- **Styling and Defaults**:
  - A new `defaultLineColor` (gray) is introduced in `Model.kt` and used as the default for `LineStyle`, `AxisConfig`, and other components.
  - `LineStyle` no longer has a `display` property. Its presence implies it should be drawn. The `color` property in `LineStyle` is now optional and defaults to `defaultLineColor`.
  - Added a `showAxisLine` boolean to `AxisConfig` to control the visibility of the main axis line.

- **Refactoring**:
  - The `LineChart` composable has been refactored to streamline the drawing logic for the left and bottom axes.
  - Simplified logic for drawing chart lines and crosshairs by removing redundant display checks.