### PR TITLE
Refactor: Make ChartConfig optional and allow auto-scaling

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tryingtorun/kmpcharts/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/tryingtorun/kmpcharts/App.kt
@@ -101,7 +101,7 @@ fun App() {
                     val data = Sample.irelandMonthlyTemperatureData
                     BarChart(
                         data = data,
-                        config = if( showMinimumConfig ) null else Config.getBarchartSampleConfig(data)
+                        config = if( showMinimumConfig ) Config.getBarchartMinimalConfig(data) else Config.getBarchartSampleConfig(data)
                     )
                 }
 
@@ -121,7 +121,7 @@ fun App() {
                     val data = Sample.bitcoinWeekly2024
                     LineChart(
                         data = data,
-                        lineChartConfig = if( showMinimumConfig) null else Config.getLineChartSampleConfig(data)
+                        lineChartConfig = if( showMinimumConfig) Config.getLineChartMinimalConfig(data) else Config.getLineChartSampleConfig(data)
                     )
                 }
 

--- a/composeApp/src/commonMain/kotlin/com/tryingtorun/kmpcharts/Config.kt
+++ b/composeApp/src/commonMain/kotlin/com/tryingtorun/kmpcharts/Config.kt
@@ -94,27 +94,20 @@ class Config {
 
         @Composable
         fun getLineChartMinimalConfig(data: List<ChartDataPoint>): LineChartConfig {
-
-            return LineChartConfig(
-                chartConfig = ChartConfig()
-            )
+            return LineChartConfig()
         }
 
         @Composable
         fun getBarchartMinimalConfig(data: List<ChartDataPoint>): BarChartConfig {
-
-            val brushes = data.map { it ->
-                val red = Random.nextFloat()
-                val green = Random.nextFloat()
-                val blue = Random.nextFloat()
-                SolidColor(Color(red = red, green = green, blue = blue))
-            }
-
-            return BarChartConfig(
-           //     barFillBrushes = brushes,
-                chartConfig = ChartConfig()
-            )
+            return BarChartConfig(chartConfig = ChartConfig(
+                leftAxisConfig = AxisConfig(
+                    scale = Scale(0.0),
+                    showLabels = false,
+                    showTicks = false
+                )
+            ))
         }
+
 
         @Composable
         fun getBarchartSampleConfig(data: List<ChartDataPoint>): BarChartConfig {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kmpcharts = "0.13.0-alpha"
+kmpcharts = "0.13.1-alpha"
 agp = "8.13.0"
 android-compileSdk = "36"
 android-minSdk = "24"

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/ChartConfig.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/ChartConfig.kt
@@ -67,9 +67,9 @@ data class ChartConfig(
 )
 
 /**
- * Defines the scale range for an axis
+ * Defines the scale range for an axis. If values are not defined then the chart will auto calculate
  */
-data class Scale( val min: Double, val max: Double)
+data class Scale( val min: Double? = null, val max: Double? = null)
 
 
 /**
@@ -163,7 +163,7 @@ data class PopupConfig(
  */
 data class LineChartConfig(
 
-    val chartConfig: ChartConfig,
+    val chartConfig: ChartConfig = ChartConfig(),
 
     /**
      * The brush to use to fill under the line
@@ -197,7 +197,8 @@ data class LineChartConfig(
  */
 data class BarChartConfig(
 
-    val chartConfig: ChartConfig,
+    val chartConfig: ChartConfig = ChartConfig(),
+
     /**
      * The width of each bar compared to the space available
      */

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/ChartHelper.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/ChartHelper.kt
@@ -431,12 +431,14 @@ internal fun DrawScope.drawLeftAxisLabelsAndTicks(
         /**
          * Draw axis line
          */
-        drawLine(
-            color = config.leftAxisConfig.lineStyle.color,
-            start = Offset(size.width, 0f),
-            end = Offset(size.width, height),
-            strokeWidth = config.leftAxisConfig.lineStyle.stroke.width
-        )
+        if( config.leftAxisConfig.showAxisLine) {
+            drawLine(
+                color = config.leftAxisConfig.lineStyle.color,
+                start = Offset(size.width, 0f),
+                end = Offset(size.width, height),
+                strokeWidth = config.leftAxisConfig.lineStyle.stroke.width
+            )
+        }
 
 
         for (i in 1..config.leftAxisConfig.numberOfLabelsToShow) {
@@ -514,18 +516,20 @@ internal fun DrawScope.drawBottomAxisLabelsAndTicks(
 ) {
 
     if (config.bottomAxisConfig != null) {
-        // the starting x-coord that everything else works from as the canvas covers the full width of the chart (to avoid clipping)
+        // the starting x-co-ord that everything else works from as the canvas covers the full width of the chart (to avoid clipping)
         val startX = chartDimensions.leftAreaWidthPixels + barWidth.toPx(density)
 
         /**
          * Draw the axis line
          */
+        if( config.bottomAxisConfig.showAxisLine) {
             drawLine(
                 color = config.bottomAxisConfig.lineStyle.color,
                 strokeWidth = config.bottomAxisConfig.lineStyle.stroke.width,
                 start = Offset(x = startX, 0f),
                 end = Offset(size.width, 0f),
             )
+        }
 
         if (config.bottomAxisMethod == BottomAxisTicksAndLabelsDrawMethod.MATCH_POINT) {
 
@@ -614,7 +618,7 @@ internal fun DrawScope.drawBottomAxisLabelsAndTicks(
                 val isFirst = index == 0
                 val isLast = index == equallyDividedXPositions.size - 1
 
-                val xValue = equallyDividedXValues[index].toDouble()
+                val xValue = equallyDividedXValues[index]
 
                 // get the label details
                 val label = config.bottomAxisConfig.valueFormatter(xValue)

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/LineChart.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/LineChart.kt
@@ -160,20 +160,24 @@ fun LineChart(
 
                         }
 
+                        var modifier = Modifier.fillMaxSize()
+
+                        if (lineChartConfig?.chartConfig?.popupConfig != null) {
+                            modifier = modifier.draggable(
+                                state = draggableState,
+                                orientation = Orientation.Horizontal,
+                                onDragStarted = { offset ->
+                                    dragPosition = offset
+                                },
+                                onDragStopped = {
+                                    showPopup = false
+                                    selectedIndex = null
+                                }
+                            )
+                        }
+
                         Canvas(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .draggable(
-                                    state = draggableState,
-                                    orientation = Orientation.Horizontal,
-                                    onDragStarted = { offset ->
-                                        dragPosition = offset
-                                    },
-                                    onDragStopped = {
-                                        showPopup = false
-                                        selectedIndex = null
-                                    }
-                                )
+                            modifier = modifier
                         ) {
 
                             drawChartLine(
@@ -310,7 +314,7 @@ fun LineChart(
                             val selectedData = data[selectedIndex!!]
                             val selectedCoordinate = coordinates[selectedIndex!!]
 
-                            if (showPopup && config != null ) {
+                            if (showPopup && config != null) {
                                 PopupBox(
                                     data = selectedData,
                                     config = config,
@@ -371,7 +375,7 @@ private fun DrawScope.drawChartLine(
     drawPath(
         path = smoothPath,
         color = config?.lineStyle?.color ?: defaultLineColor,
-        style = config?.lineStyle?.stroke ?: Stroke(width=10f)
+        style = config?.lineStyle?.stroke ?: Stroke(width = 10f)
     )
 
 }

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/Model.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/Model.kt
@@ -64,7 +64,7 @@ data class AxisConfig(
     /**
      * Whether or not to show labels for each point on the axis
      */
-    val showAxisLine: Boolean = true,
+    val showAxisLine: Boolean = showTicks,
 
     /**
      * The length of the ticks


### PR DESCRIPTION
This commit introduces several enhancements and refactors:

- **Optional Chart Configurations:**
  - `LineChartConfig` and `BarChartConfig` no longer require an explicit `ChartConfig`. They now use a default `ChartConfig()` if one is not provided, simplifying minimal chart setups.

- **Auto-Scaling Axes:**
  - The `Scale` data class now has nullable `min` and `max` properties (`Double?`).
  - If `min` or `max` is not provided, the chart will automatically calculate the scale based on the data.

- **Conditional Dragging:**
  - Drag functionality on the `LineChart` is now only enabled if a `popupConfig` is provided, preventing unnecessary recompositions and behavior when popups are not used.

- **Axis Line Visibility Control:**
  - The `showAxisLine` property in `AxisConfig` now defaults to the value of `showTicks`, providing more intuitive default behavior for hiding axis elements. Direct control is still possible.

- **Sample App Updates:**
  - The sample app now demonstrates the new minimal configuration for both `LineChart` and `BarChart`.