### PR TITLE
feat: Hide axis areas when labels, ticks, and lines are disabled

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kmpcharts = "0.13.1-alpha"
+kmpcharts = "0.13.2-alpha"
 agp = "8.13.0"
 android-compileSdk = "36"
 android-minSdk = "24"

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/BarChart.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/BarChart.kt
@@ -89,18 +89,19 @@ fun BarChart(
 
                 Box(modifier = Modifier.fillMaxSize()) {
 
-                    /**
-                     * Left area axis, ticks and labels
-                     */
-                    Box(
-                        modifier = Modifier
-                            .width(chartDimensions.leftAreaWidth)
+                    val chartConfig = config?.chartConfig
+                    if (chartConfig?.bottomAxisConfig != null
+                        && (chartConfig.bottomAxisConfig.showTicks || chartConfig.bottomAxisConfig.showLabels || chartConfig.bottomAxisConfig.showAxisLine)
                     ) {
-                        Canvas(
-                            modifier = Modifier.fillMaxSize()
+                        /**
+                         * Left area axis, ticks and labels
+                         */
+                        Box(
+                            modifier = Modifier.width(chartDimensions.leftAreaWidth)
                         ) {
-
-                            if( config != null ) {
+                            Canvas(
+                                modifier = Modifier.fillMaxSize()
+                            ) {
                                 drawLeftAxisLabelsAndTicks(
                                     density = density,
                                     textMeasurer = textMeasurer,
@@ -127,7 +128,7 @@ fun BarChart(
                             }
                     ) {
 
-                        if( config != null ) {
+                        if (config != null) {
                             Canvas(modifier = Modifier.fillMaxSize()) {
 
                                 drawBottomAxisLabelsAndTicks(
@@ -167,8 +168,7 @@ fun BarChart(
                         }
 
                         var modifier = Modifier.fillMaxSize()
-                        if( config?.chartConfig?.popupConfig != null  )
-                        {
+                        if (config?.chartConfig?.popupConfig != null) {
                             modifier = modifier.draggable(
                                 state = draggableState,
                                 orientation = Orientation.Horizontal,
@@ -361,7 +361,7 @@ fun BarChart(
                             val selectedData = data[selectedIndex!!]
                             val selectedCoordinate = coordinates[selectedIndex!!]
 
-                            if ( config != null && showPopup) {
+                            if (config != null && showPopup) {
                                 PopupBox(
                                     data = selectedData,
                                     config = config.chartConfig,

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/ChartHelper.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/ChartHelper.kt
@@ -88,7 +88,7 @@ object ChartHelper {
         textMeasurer: TextMeasurer
     ): IntSize {
 
-        if (config.leftAxisConfig == null)
+        if (config.leftAxisConfig == null || !config.leftAxisConfig.showLabels)
             return IntSize(0, 0)
 
         val largestValue = data.maxOfOrNull { it.yValue } ?: 0.0
@@ -211,40 +211,38 @@ object ChartHelper {
         /**
          * Calculations for left and bottom axis labels
          */
-        val leftLabelSize = if (config == null) IntSize(0, 0) else
-            if (config.leftAxisConfig == null) IntSize(
-                0,
-                0
-            ) else calculateLeftAxisLabelSize(
+        val leftLabelSizePixels =
+            if (config?.leftAxisConfig == null || !config.leftAxisConfig.showLabels) IntSize(
+                width = 0,
+                height = 0
+            )
+            else calculateLeftAxisLabelSize(
                 density = density,
                 data = data,
                 config = config,
                 textMeasurer = textMeasurer
             )
 
-        val leftLabelMaxWidth = if (config == null) 0.dp else
-            if (config.leftAxisConfig?.lineStyle != null) with(
-                density
-            ) { leftLabelSize.width.toDp() } else 0.dp
-
-        val bottomLabelSize =
-            if (config != null && config.bottomAxisConfig != null) calculateBottomAxisLabelSize(
+        val bottomLabelSizePixels =
+            if (config?.bottomAxisConfig == null || !config.bottomAxisConfig.showLabels) IntSize(
+                width = 0,
+                height = 0
+            )
+            else calculateBottomAxisLabelSize(
                 data,
                 config,
                 textMeasurer
-            ) else IntSize(0, 0)
+            )
 
-        val bottomLabelHeight = with(density) { bottomLabelSize.height.toDp() }
-        val bottomAreaHeight = if (config == null) 0.dp else
-            if (config.bottomAxisConfig == null) 0.dp else
-                bottomLabelHeight + config.bottomAxisConfig.labelPadding.calculateTopPadding() + config.bottomAxisConfig.labelPadding.calculateBottomPadding() + config.bottomAxisConfig.tickLength
 
-        val leftAreaWidth = if (config == null) 0.dp else
-            if (config.leftAxisConfig != null) leftLabelMaxWidth.plus(
-                (if (config.leftAxisConfig.showLabels) config.leftAxisConfig.labelPadding.leftPadding + config.leftAxisConfig.labelPadding.endPadding else 0.dp)
-            ).plus(
-                (if (config.leftAxisConfig.showTicks) config.leftAxisConfig.tickLength else 0.dp)
-            ) else 0.dp
+        val bottomAreaHeight = if (config?.bottomAxisConfig == null) 0.dp else
+            with(density) { bottomLabelSizePixels.height.toDp() } + config.bottomAxisConfig.labelPadding.calculateTopPadding() + config.bottomAxisConfig.labelPadding.calculateBottomPadding() + config.bottomAxisConfig.tickLength
+
+        val leftAreaWidth = if (config?.leftAxisConfig == null) 0.dp else {
+            with(density) {
+                leftLabelSizePixels.width.toDp() + if (config.leftAxisConfig.showTicks) config.leftAxisConfig.tickLength else 0.dp + if (config.leftAxisConfig.showLabels) config.leftAxisConfig.labelPadding.leftPadding + config.leftAxisConfig.labelPadding.endPadding else 0.dp
+            }
+        }
 
 
         val plotAreaHeight = height - bottomAreaHeight
@@ -256,13 +254,13 @@ object ChartHelper {
             plotAreaHeight = plotAreaHeight,
             plotAreaWidth = plotAreaWidth,
             bottomAreaHeight = bottomAreaHeight,
-            leftAxisLabelHeight = with(density) { leftLabelSize.height.toDp() },
+            leftAxisLabelHeight = with(density) { leftLabelSizePixels.height.toDp() },
 
             leftAreaWidthPixels = with(density) { leftAreaWidth.toPx() },
             plotAreaHeightPixels = with(density) { plotAreaHeight.toPx() },
             plotAreaWidthPixels = with(density) { plotAreaWidth.toPx() },
             bottomAreaHeightPixels = with(density) { bottomAreaHeight.toPx() },
-            leftAxisLabelHeightPixels = with(density) { leftLabelSize.height.toDp().toPx() }
+            leftAxisLabelHeightPixels = leftLabelSizePixels.height.toFloat()
         )
     }
 
@@ -431,7 +429,7 @@ internal fun DrawScope.drawLeftAxisLabelsAndTicks(
         /**
          * Draw axis line
          */
-        if( config.leftAxisConfig.showAxisLine) {
+        if (config.leftAxisConfig.showAxisLine) {
             drawLine(
                 color = config.leftAxisConfig.lineStyle.color,
                 start = Offset(size.width, 0f),
@@ -522,7 +520,7 @@ internal fun DrawScope.drawBottomAxisLabelsAndTicks(
         /**
          * Draw the axis line
          */
-        if( config.bottomAxisConfig.showAxisLine) {
+        if (config.bottomAxisConfig.showAxisLine) {
             drawLine(
                 color = config.bottomAxisConfig.lineStyle.color,
                 strokeWidth = config.bottomAxisConfig.lineStyle.stroke.width,

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/LineChart.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/LineChart.kt
@@ -82,7 +82,7 @@ fun LineChart(
 
                 Box(modifier = Modifier.fillMaxSize()) {
 
-                    if (config?.leftAxisConfig != null) {
+                    if (config?.leftAxisConfig != null && (config.leftAxisConfig.showTicks || config.leftAxisConfig.showLabels || config.leftAxisConfig.showAxisLine ) ) {
 
                         /**
                          * Left area axis, ticks and labels


### PR DESCRIPTION
This commit optimizes chart rendering by completely hiding the left and bottom axis areas if `showAxisLine`, `showTicks`, and `showLabels` are all set to `false` in the axis configuration.

- **`BarChart.kt` & `LineChart.kt`**:
    - The left and bottom axis areas will no longer be composed if all their respective components (axis line, ticks, labels) are configured to be hidden.

- **`ChartHelper.kt`**:
    - Updated `calculateChartDimensions` to no longer allocate space for axis areas if the labels are not shown.
    - Axis label size calculation (`calculateLeftAxisLabelSize`) now returns `IntSize(0, 0)` if labels are disabled, preventing unnecessary measurement.