### PR TITLE
feat: Changed ChartDataPoint and DataPointPlotCoordinates to use var

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kmpcharts = "0.13.2-alpha"
+kmpcharts = "0.13.3-alpha"
 agp = "8.13.0"
 android-compileSdk = "36"
 android-minSdk = "24"

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/Model.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/Model.kt
@@ -20,18 +20,18 @@ val defaultLineColor = Color.Gray // default color used that works for both them
  * Data class representing a single bar in the chart
  */
 data class ChartDataPoint(
-    val xValue: Double,
-    val yValue: Double,
-    val summary: String
+    var xValue: Double,
+    var yValue: Double,
+    var summary: String
 )
 
 /**
  * Data class representing a single point in the chart plot area
  */
 data class DataPointPlotCoordinates(
-    val x: Float,
-    val y: Float,
-    val dataPoint: ChartDataPoint
+    var x: Float,
+    var y: Float,
+    var dataPoint: ChartDataPoint
 )
 
 data class AxisConfig(


### PR DESCRIPTION
The properties of `ChartDataPoint` and `DataPointPlotCoordinates` have been changed from `val` to `var` to allow them to be mutable. The library version has also been updated.