### PR TITLE
refactor: Make AxisConfig self-contained and remove it from ChartConfig

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tryingtorun/kmpcharts/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/tryingtorun/kmpcharts/App.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -24,28 +23,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import com.tryingtorun.kmpcharts.library.AxisConfig
 import com.tryingtorun.kmpcharts.library.BarChart
-import com.tryingtorun.kmpcharts.library.BarChartConfig
-import com.tryingtorun.kmpcharts.library.BottomAxisTicksAndLabelsDrawMethod
-import com.tryingtorun.kmpcharts.library.ChartConfig
-import com.tryingtorun.kmpcharts.library.HorizontalGuideLineConfig
 import com.tryingtorun.kmpcharts.library.LineChart
-import com.tryingtorun.kmpcharts.library.LineChartConfig
-import com.tryingtorun.kmpcharts.library.PopupConfig
-import com.tryingtorun.kmpcharts.library.RangeRectangleConfig
 import com.tryingtorun.kmpcharts.library.Sample
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.ui.tooling.preview.Preview
-import kotlin.random.Random
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 

--- a/composeApp/src/commonMain/kotlin/com/tryingtorun/kmpcharts/Config.kt
+++ b/composeApp/src/commonMain/kotlin/com/tryingtorun/kmpcharts/Config.kt
@@ -8,8 +8,8 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.tryingtorun.kmpcharts.library.AxisConfig
+import com.tryingtorun.kmpcharts.library.AxisTicksAndLabelsDrawMethod
 import com.tryingtorun.kmpcharts.library.BarChartConfig
-import com.tryingtorun.kmpcharts.library.BottomAxisTicksAndLabelsDrawMethod
 import com.tryingtorun.kmpcharts.library.ChartConfig
 import com.tryingtorun.kmpcharts.library.ChartDataPoint
 import com.tryingtorun.kmpcharts.library.HorizontalGuideLineConfig
@@ -65,7 +65,6 @@ class Config {
                             ),
                         )
                     ),
-                    bottomAxisMethod = BottomAxisTicksAndLabelsDrawMethod.DIVIDE_EQUALLY,
                     bottomAxisConfig = AxisConfig(
                         valueFormatter = {
                             it.toInt().toDateString()
@@ -182,12 +181,10 @@ class Config {
                         valueFormatter = {
                             when (it.toInt()) {
                                 in 1..12 -> it.toInt().toMonthShortName()
-                                    .take(3)
-
                                 else -> throw IllegalArgumentException("Month number must be between 1 and 12")
                             }
                         },
-                        numberOfLabelsToShow = 4, // don't want clutter on the bottom axis then change this, depending on your data set
+                        numberOfLabelsToShow = 6, // don't want clutter on the bottom axis then change this, depending on your data set
                         shiftLastLabel = false, // shift the last label to the left to avoid clipping if not using rightgutterwidth above
                     ),
                     leftAxisConfig = AxisConfig(
@@ -196,8 +193,9 @@ class Config {
                             "${it.toInt()}°C"
                         },
                         numberOfLabelsToShow = 5,
-                        showLabels = true,
-                        showTicks = true,
+                        showLabels = false,
+                        showTicks = false,
+                        showAxisLine = false
                     )
                 )
             )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kmpcharts = "0.13.3-alpha"
+kmpcharts = "0.13.4-alpha"
 agp = "8.13.0"
 android-compileSdk = "36"
 android-minSdk = "24"

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/BarChart.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/BarChart.kt
@@ -90,8 +90,9 @@ fun BarChart(
                 Box(modifier = Modifier.fillMaxSize()) {
 
                     val chartConfig = config?.chartConfig
-                    if (chartConfig?.bottomAxisConfig != null
-                        && (chartConfig.bottomAxisConfig.showTicks || chartConfig.bottomAxisConfig.showLabels || chartConfig.bottomAxisConfig.showAxisLine)
+
+                    if (chartConfig?.leftAxisConfig != null
+                        && (chartConfig.leftAxisConfig.showTicks || chartConfig.leftAxisConfig.showLabels || chartConfig.leftAxisConfig.showAxisLine)
                     ) {
                         /**
                          * Left area axis, ticks and labels
@@ -116,25 +117,25 @@ fun BarChart(
                     /**
                      * Bottom area axis, ticks and labels
                      */
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(chartDimensions.bottomAreaHeight)
-                            .offset {
-                                IntOffset(
-                                    0,
-                                    (heightPixels - chartDimensions.bottomAreaHeightPixels).toInt()
-                                )
-                            }
+                    if (chartConfig?.bottomAxisConfig != null
+                        && (chartConfig.bottomAxisConfig.showTicks || chartConfig.bottomAxisConfig.showLabels || chartConfig.bottomAxisConfig.showAxisLine)
                     ) {
-
-                        if (config != null) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(chartDimensions.bottomAreaHeight)
+                                .offset {
+                                    IntOffset(
+                                        0,
+                                        (heightPixels - chartDimensions.bottomAreaHeightPixels).toInt()
+                                    )
+                                }
+                        ) {
                             Canvas(modifier = Modifier.fillMaxSize()) {
-
                                 drawBottomAxisLabelsAndTicks(
                                     density = density,
                                     textMeasurer = textMeasurer,
-                                    config = config.chartConfig,
+                                    config = config.chartConfig.bottomAxisConfig,
                                     chartDimensions = chartDimensions,
                                     coordinates = coordinates
                                 )

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/ChartConfig.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/ChartConfig.kt
@@ -40,11 +40,6 @@ data class ChartConfig(
 
 
     /**
-     * The method to use to draw ticks and labels on the bottom axis
-     */
-    val bottomAxisMethod: BottomAxisTicksAndLabelsDrawMethod = BottomAxisTicksAndLabelsDrawMethod.MATCH_POINT,
-
-    /**
      * The horizontal guide lines to draw on the chart
      */
     val horizontalGuideLines: List<HorizontalGuideLineConfig> = emptyList(),
@@ -76,7 +71,7 @@ data class Scale( val min: Double? = null, val max: Double? = null)
  * Method to use to display labels and ticks on the bottom axis. If MATCH_POINT the ticks and labels will be drawn for each data point.
  * If DIVIDE_EQUALLY is used, the ticks and labels will be drawn dividing the axis equally based on the number of labels to show
  */
-enum class BottomAxisTicksAndLabelsDrawMethod {
+enum class AxisTicksAndLabelsDrawMethod {
     MATCH_POINT, DIVIDE_EQUALLY
 }
 

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/LineChart.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/LineChart.kt
@@ -126,7 +126,7 @@ fun LineChart(
                                 drawBottomAxisLabelsAndTicks(
                                     density = density,
                                     textMeasurer = textMeasurer,
-                                    config = config,
+                                    config = config.bottomAxisConfig,
                                     chartDimensions = chartDimensions,
                                     coordinates = coordinates
                                 )

--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/Model.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/Model.kt
@@ -104,8 +104,15 @@ data class AxisConfig(
      * Whether or not to shift the last label up or to the right to ensure it is visible
      * If you set this to false, then use gutter widths on the chart config to allow space and ensure these labels are not cut off
      */
-    val shiftLastLabel: Boolean = false
+    val shiftLastLabel: Boolean = false,
 
+
+    /**
+     * The method to use to draw ticks and labels on the axis
+     * AxisTicksAndLabelsDrawMethod.MATCH_POINT will draw ticks and labels for each data point on the axis
+     * AxisTicksAndLabelsDrawMethod.DIVIDE_EQUALLY will draw ticks and labels equally spaced along the axis
+     */
+    val ticksAndLabelsDrawMethod: AxisTicksAndLabelsDrawMethod = AxisTicksAndLabelsDrawMethod.MATCH_POINT,
 )
 
 data class LineStyle(


### PR DESCRIPTION
This commit refactors the chart configuration by decoupling `AxisConfig` from the main `ChartConfig`.

Key changes:
- `bottomAxisMethod` has been removed from `ChartConfig`.
- A new `ticksAndLabelsDrawMethod` property has been added to `AxisConfig` to control how ticks and labels are drawn (`MATCH_POINT` vs. `DIVIDE_EQUALLY`).
- The `AxisTicksAndLabelsDrawMethod` enum was renamed from `BottomAxisTicksAndLabelsDrawMethod` for broader applicability.
- The `drawBottomAxisLabelsAndTicks` helper function is now self-contained, accepting an `AxisConfig` directly instead of the parent `ChartConfig`.
- The BarChart's axis drawing logic has been corrected to properly check the visibility of the left and bottom axes independently.