### PR TITLE
refactor: Make AxisConfig self-contained and remove it from ChartConfig

### DIFF
--- a/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/BarChart.kt
+++ b/library/src/commonMain/kotlin/com/tryingtorun/kmpcharts/library/BarChart.kt
@@ -224,8 +224,8 @@ fun BarChart(
                                         textMeasurer = textMeasurer,
                                         text = label,
                                         topLeft = Offset(
-                                            x = coordinate.x - textMeasurer.measure(label).size.width / 2,
-                                            y = coordinate.y - textMeasurer.measure(label).size.height - 5.dp.toPx(
+                                            x = coordinate.x - textMeasurer.measure(label, style = config.labelTextStyle).size.width / 2,
+                                            y = coordinate.y - textMeasurer.measure(label, style = config.labelTextStyle).size.height - 5.dp.toPx(
                                                 density
                                             )
                                         )


### PR DESCRIPTION
This commit refactors the chart configuration by decoupling `AxisConfig` from the main `ChartConfig`.

Key changes:
- `bottomAxisMethod` has been removed from `ChartConfig`.
- A new `ticksAndLabelsDrawMethod` property has been added to `AxisConfig` to control how ticks and labels are drawn (`MATCH_POINT` vs. `DIVIDE_EQUALLY`).
- The `AxisTicksAndLabelsDrawMethod` enum was renamed from `BottomAxisTicksAndLabelsDrawMethod` for broader applicability.
- The `drawBottomAxisLabelsAndTicks` helper function is now self-contained, accepting an `AxisConfig` directly instead of the parent `ChartConfig`.
- The BarChart's axis drawing logic has been corrected to properly check the visibility of the left and bottom axes independently.